### PR TITLE
Rename crate name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rust-codecov"
+name = "codecov"
 version = "0.1.0"
 edition = "2021"
 authors = ["Yui Kitsu <kitsuyui+github@kitsuyui.com>"]
@@ -7,7 +7,7 @@ description = "Codecov API client for Rust"
 license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/kitsuyui/rust-codecov"
-documentation = "https://docs.rs/rust-codecov"
+documentation = "https://docs.rs/codecov"
 categories = ["api-bindings"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # rust-codecov
 
-[![Crates.io](https://img.shields.io/crates/d/rust-codecov)](https://crates.io/crates/rust-codecov)
+[![Crates.io](https://img.shields.io/crates/d/codecov)](https://crates.io/crates/codecov)
 [![codecov](https://codecov.io/gh/kitsuyui/rust-codecov/branch/main/graph/badge.svg?token=0OM9KWFZQC)](https://codecov.io/gh/kitsuyui/rust-codecov)
-[![crates.io](https://img.shields.io/crates/v/rust-codecov.svg)](https://crates.io/crates/rust-codecov)
+[![crates.io](https://img.shields.io/crates/v/codecov.svg)](https://crates.io/crates/codecov)
 
 ## Description
 
@@ -12,7 +12,7 @@ https://docs.codecov.com/reference/overview
 ## Usage
 
 ```rust
-use rust_codecov::{Client, Owner};
+use codecov::{Client, Owner};
 
 // let client = Client::new("1234-5678-9012-3456");
 let client = Client::new_from_env();  // Read from CODECOV_OWNER_TOKEN


### PR DESCRIPTION
- https://rust-lang.github.io/api-guidelines/naming.html

> Crate names should not use -rs or -rust as a suffix or prefix. Every crate is Rust! It serves no purpose to remind users of this constantly.
