### PR TITLE
Bump v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codecov"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Yui Kitsu <kitsuyui+github@kitsuyui.com>"]
 description = "Codecov API client for Rust"


### PR DESCRIPTION
- Breaking changes: crate name is renamed to `codecov` instead `rust-codecov`
