### PR TITLE
Fix: DeserializeError(Error("data did not match any variant of untagged enum BranchDetailAPIResponse", line: 0, column: 0))

### DIFF
--- a/src/branch_detail.rs
+++ b/src/branch_detail.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-use crate::author::Author;
 use crate::totals::Totals;
 
 /**
@@ -49,6 +48,18 @@ pub struct HeadCommit {
 }
 
 /**
+ * Author is a struct that represents an author.
+ * Note: username is an optional field.
+ * if the author is a bot, username will be null.
+ */
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Author {
+    pub name: String,
+    pub service: String,
+    pub username: Option<String>,
+}
+
+/**
  * Report is a struct that represents a report.
  */
 #[derive(Serialize, Deserialize, Debug)]
@@ -84,5 +95,113 @@ impl BranchDetailAPISuccessResponse {
      */
     pub fn latest_coverage(&self) -> f64 {
         self.head_commit.totals.coverage
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_deserialize_branch_detail_api_response() {
+        let j = json!({
+            "head_commit": {
+                "author": {
+                    "name": "renovate[bot]",
+                    "service": "github",
+                    "username": null
+                },
+                "branch": "main",
+                "ci_passed": true,
+                "commitid": "1eb341765e7c3daa88ae5d2a751538a620c6dbce",
+                "message": "chore(deps): update dependency @swc/core to v1.3.73",
+                "parent": "5a4b2987ca3a8a7b54efac914fd72455ebff50ba",
+                "report": {
+                    "files": [],
+                    "totals": {
+                        "branches": 22,
+                        "complexity": 0.0,
+                        "complexity_ratio": 0,
+                        "complexity_total": 0.0,
+                        "coverage": 86.05,
+                        "diff": 0,
+                        "files": 10,
+                        "hits": 148,
+                        "lines": 172,
+                        "messages": 0,
+                        "methods": 0,
+                        "misses": 23,
+                        "partials": 1,
+                        "sessions": 1
+                    }
+                },
+                "state": "complete",
+                "timestamp": "2023-08-01T15:41:47Z",
+                "totals": {
+                    "branches": 22,
+                    "complexity": 0.0,
+                    "complexity_ratio": 0,
+                    "complexity_total": 0.0,
+                    "coverage": 86.05,
+                    "diff": 0,
+                    "files": 10,
+                    "hits": 148,
+                    "lines": 172,
+                    "methods": 0,
+                    "misses": 23,
+                    "partials": 1,
+                    "sessions": 1
+                }
+            },
+            "name": "main",
+            "updatestamp": "2023-08-01T19:10:56.045522Z"
+        });
+        serde_json::from_value::<BranchDetailAPIResponse>(j).unwrap();
+    }
+
+    #[test]
+    fn test_deserialize_report() {
+        let j = json!({
+            "files": [
+                {
+                    "name": "src/something.ts",
+                    "totals": {
+                        "branches": 1,
+                        "complexity": 0.0,
+                        "complexity_ratio": 0,
+                        "complexity_total": 0.0,
+                        "coverage": 0.0,
+                        "diff": 0,
+                        "files": 0,
+                        "hits": 0,
+                        "lines": 12,
+                        "messages": 0,
+                        "methods": 0,
+                        "misses": 12,
+                        "partials": 0,
+                        "sessions": 0
+                    }
+                },
+            ],
+            "totals": {
+                "branches": 22,
+                "complexity": 0.0,
+                "complexity_ratio": 0,
+                "complexity_total": 0.0,
+                "coverage": 86.05,
+                "diff": 0,
+                "files": 10,
+                "hits": 148,
+                "lines": 172,
+                "messages": 0,
+                "methods": 0,
+                "misses": 23,
+                "partials": 1,
+                "sessions": 1
+            }
+        });
+        serde_json::from_value::<Report>(j).unwrap();
     }
 }

--- a/src/commits.rs
+++ b/src/commits.rs
@@ -20,6 +20,8 @@ pub struct CommitsAPIResponse {
 
 /**
  * CommitAuthor is a struct that represents the author of a commit.
+ * Note: This is different from the Author struct in src/author.rs.
+ * name is optional in this struct.
  */
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CommitAuthor {


### PR DESCRIPTION
head_commit.author.username can be null. This error occurred because the response from the API could not be deserialized because this consideration was not taken into account. Fix this.

username is null when a bot on GitHub commits.
