### PR TITLE
Remove duplicate events

### DIFF
--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -1,8 +1,8 @@
 name: publish crates
 
 on:
-  push:
   pull_request:
+    types: [opened, synchronize]
   release:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,6 +1,5 @@
 name: Spellcheck
 on:
-  - push
   - pull_request
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,5 @@
 name: tests
 on:
-  - push
   - pull_request
 
 jobs:


### PR DESCRIPTION
I noticed that it is not necessary to specify both push and pull_request in GitHub Workflow.
The synchronize event of pull_request performs the same processing as the push event in most cases.
Specify only pull_request.
