### PR TITLE
Send coverage report to Codecov after merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 name: tests
 on:
-  - pull_request
+  # pull-request events are not triggered when a PR is merged
+  # push events are triggered when a PR is created in a fork
+  # So we need both to run tests on every PR and after merging
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   check:


### PR DESCRIPTION
- on: pull-request events are not triggered when a PR is merged
- on: push events are not triggered when a PR is created in a fork

So we need to run the tests both on push and on pull-request events.
